### PR TITLE
Add basic ci/cd for release cutting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Build container against PR
+
+on:
+  pull_request:
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5.1.0
+        with:
+          context: .
+          push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  release: 
+    types: published
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+    test-build-release:
+        runs-on: ubuntu-latest
+        permissions:
+          contents: read
+          packages: write
+        steps:
+            # Setup
+            - uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
+
+            # Build docker image, push to GitHub Packages
+            - name: Log in to the Container registry
+              uses: docker/login-action@v3.0.0
+              with:
+                registry: ${{ env.REGISTRY }}
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@v5.4.0
+              with:
+                images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                tags: |
+                  type=ref,event=tag
+                  type=sha
+
+            - name: Build and push Docker image
+              uses: docker/build-push-action@v5.1.0
+              with:
+                context: .
+                push: true
+                tags: ${{ steps.meta.outputs.tags }}
+                labels: ${{ steps.meta.outputs.labels }}
+            


### PR DESCRIPTION
Cut a release on the repository and an action will cut and build the repo into usable docker images that are published to the GitHub packages store.


Figured I’d pr this in case it was wanted, I’m using it on my fork already.